### PR TITLE
Replace set_script_meta with set_script_tooled

### DIFF
--- a/plugins/addons/custom_dock/dock_plugin.js
+++ b/plugins/addons/custom_dock/dock_plugin.js
@@ -11,4 +11,4 @@ export default class CustomDock extends godot.EditorPlugin {
 		this.dock.free();
 	}
 }
-godot.set_script_meta(CustomDock, true);
+godot.set_script_tooled(CustomDock, true);

--- a/plugins/addons/custom_node/heart.js
+++ b/plugins/addons/custom_node/heart.js
@@ -11,4 +11,4 @@ export default class Heart extends godot.Node2D {
 		return rect;
 	}
 }
-godot.set_script_meta(Heart, true);
+godot.set_script_tooled(Heart, true);

--- a/plugins/addons/custom_node/heart_plugin.js
+++ b/plugins/addons/custom_node/heart_plugin.js
@@ -12,4 +12,4 @@ export default class HeartPlugin extends godot.EditorPlugin {
 		this.remove_custom_type("Heart");
 	}
 }
-godot.set_script_meta(HeartPlugin, true);
+godot.set_script_tooled(HeartPlugin, true);


### PR DESCRIPTION
Addons demo was not working, was producing "not a function" error since `set_script_meta` was replaced in favour of `set_script_tooled` and `set_script_icon`.